### PR TITLE
Call 15.03.23 Updates

### DIFF
--- a/LSPS1/LSPS1.yaml
+++ b/LSPS1/LSPS1.yaml
@@ -42,15 +42,13 @@ paths:
                 schema:
                     $ref: "#/components/schemas/ApiInfoResponse"
                 example:
-                  version: 2
+                  versions: [2]
                   website: "http://example.com/contact"
-                  extensions:
-                    base_api:
-                      version: 1
-                      max_user_balance_satoshi: "0"
-                      max_lsp_balance_satoshi: "100000000"
-                      min_required_onchain_satoshi: null
-                      max_channel_expiry_blocks: 144
+                  options:
+                    max_user_balance_satoshi: "0"
+                    max_lsp_balance_satoshi: "100000000"
+                    min_required_onchain_satoshi: null
+                    max_channel_expiry_blocks: 144
   
     post:
       tags:
@@ -149,67 +147,55 @@ paths:
 
 components:
     schemas:
+
       ApiInfoResponse:
         type: "object"
         properties:
-          version:
-            type: integer
-            description: "Version of this api. See https://github.com/BitcoinAndLightningLayerSpecs/lsp"
-            example: 1
+          versions:
+            type: array
+            items:
+              type: integer
+            description: "Supported versions of this api. See https://github.com/BitcoinAndLightningLayerSpecs/lsp"
+            example: [2]
           options:
             type: object
             additionalProperties:
-              $ref: "#/components/schemas/ExtensionOptions"
+              $ref: "#/components/schemas/ApiOptions"
           website:
             type: string
             description: "Website that provides devs a way to get in contact and/or TOS."
             example: "https://blocktank.to/contact"
-      
-      AbstractExtensionOptions: # All extensions derive from this schema.
+
+      ApiOptions: # Options for the base api.
         type: object
         properties:
-          version:
+          max_user_balance_satoshi:
+            type: string
+            description: "Maximal number of satoshi that the LSP is willing to push to the user side."
+            example: "100000000"
+          max_lsp_balance_satoshi:
+            type: string
+            description: "Maximal number of satoshi that the LSP is willing to contribute to the lsp balance."
+            example: "100000000"
+          min_required_onchain_satoshi:
+            type: string
+            description: "Minimal number of satoshi required to allow onchain payments. Null for unsupported."
+            example: "9999"
+            nullable: true
+          max_channel_expiry_blocks:
             type: integer
-            example: 1
-            default: 1
-            description: Version of this extension. Integer starting at 1 counting up.
-
-      BaseApiOptionsV1: # Options for the base api.
-        allOf:
-          - $ref: "#/components/schemas/AbstractExtensionOptions" # Extends BaseExtension
-          - type: object
-            properties:
-              version:
-                type: integer
-                example: 1
-                default: 1
-              max_user_balance_satoshi:
-                type: string
-                description: "Maximal number of satoshi that the LSP is willing to push to the user side."
-                example: "100000000"
-              max_lsp_balance_satoshi:
-                type: string
-                description: "Maximal number of satoshi that the LSP is willing to contribute to the lsp balance."
-                example: "100000000"
-              min_required_onchain_satoshi:
-                type: string
-                description: "Minimal number of satoshi required to allow onchain payments. Null for unsupported."
-                example: "9999"
-                nullable: true
-              max_channel_expiry_blocks:
-                type: integer
-                description: "Maximal number of blocks a channel can be leased for."
-                example: 24
-
-      ExtensionOptions: # Schema of all allowed options.
-        oneOf: # One of these types need to match
-          - $ref: "#/components/schemas/BaseApiOptionsV1"
+            description: "Maximal number of blocks a channel can be leased for."
+            example: 24
     
       OrderRequest:
         type: object
         required:
           - details
         properties:
+          api_version:
+            type: integer
+            example: 2
+            description: "API version that is used in this request."
           order:
             $ref: "#/components/schemas/OrderParameters"
           open:

--- a/LSPS1/LSPS1.yaml
+++ b/LSPS1/LSPS1.yaml
@@ -45,6 +45,8 @@ paths:
                   versions: [2]
                   website: "http://example.com/contact"
                   options:
+                    minimum_depth: 0
+                    supports_zero_channel_reserve: true
                     max_user_balance_satoshi: "0"
                     max_lsp_balance_satoshi: "100000000"
                     min_required_onchain_satoshi: null
@@ -169,6 +171,15 @@ components:
       ApiOptions: # Options for the base api.
         type: object
         properties:
+          minimum_depth:
+            type: integer
+            example: 0
+            description: The number of blocks it requires for the LSP to send `channel_ready` (previously `funding_locked`).
+            minimum: 0
+          supports_zero_channel_reserve:
+            type: boolean
+            example: true
+            description: Indicates if the LSP supports [zeroreserve](https://github.com/ElementsProject/lightning/pull/5315).
           max_user_balance_satoshi:
             type: string
             description: "Maximal number of satoshi that the LSP is willing to push to the user side."

--- a/LSPS1/LSPS1.yaml
+++ b/LSPS1/LSPS1.yaml
@@ -50,7 +50,7 @@ paths:
                       max_user_balance_satoshi: "0"
                       max_lsp_balance_satoshi: "100000000"
                       min_required_onchain_satoshi: null
-                      max_channel_expiry_weeks: 24
+                      max_channel_expiry_blocks: 144
   
     post:
       tags:
@@ -196,9 +196,9 @@ components:
                 description: "Minimal number of satoshi required to allow onchain payments. Null for unsupported."
                 example: "9999"
                 nullable: true
-              max_channel_expiry_weeks:
+              max_channel_expiry_blocks:
                 type: integer
-                description: "Maximal number of weeks a channel can be leased for."
+                description: "Maximal number of blocks a channel can be leased for."
                 example: 24
 
       ExtensionOptions: # Schema of all allowed options.
@@ -219,7 +219,7 @@ components:
         type: "object"
         required:
           - remote_balance
-          - channel_expiry_weeks
+          - channel_expiry_blocks
         properties:
           lsp_balance_satoshi:
             type: string
@@ -236,9 +236,9 @@ components:
             type: number
             description: "On-chain fee rate of the channel opening transaction in satoshis per vbyte."
             minimum: 1
-          channel_expiry_weeks:
+          channel_expiry_blocks:
             type: integer
-            description: "Channel expiration in weeks."
+            description: "Channel expiration in blocks."
             minimum: 1
             example: 12
           coupon_code:

--- a/LSPS1/LSPS1.yaml
+++ b/LSPS1/LSPS1.yaml
@@ -218,10 +218,10 @@ components:
             default: 0
             example: "2000000"
             minimum: 0
-          onchain_fee_rate:
+          confirms_within_blocks:
             type: number
-            description: "On-chain fee rate of the channel opening transaction in satoshis per vbyte."
-            minimum: 1
+            description: "Within how many blocks MUST the funding transaction be confirmed after the user paid the order."
+            minimum: 0
           channel_expiry_blocks:
             type: integer
             description: "Channel expiration in blocks."

--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -81,23 +81,20 @@ Example `GET /lsp/channels` response:
   "versions": [2],
   "website": "http://example.com/contact",
   "options": {
-    "base_api": {
       "max_user_balance_satoshi": "0",
       "max_lsp_balance_satoshi": "100000000",
       "min_required_onchain_satoshi": null,
       "max_channel_expiry_blocks": 20160
-    }
   }
 }
 ```
 
-#### Base api options
+#### Api options
 
-The base api itself has multiple properties that MUST be defined.
+The api itself has multiple properties that MUST be defined.
 
 ```json
 "options": {
-        "versions": [2],
         "max_user_balance_satoshi": "0",
         "max_lsp_balance_satoshi": "100000000",
         "min_required_onchain_satoshi": null,
@@ -144,7 +141,7 @@ The user constructs the request body depending on their needs.
 - `order` object MUST be provided.
     - `lsp_balance_satoshi` MUST be 1 or greater. MUST be below or equal `base_api.max_lsp_balance_satoshi`.
     - `user_balance_satoshi` MUST be 0 or greater. MUST be below or equal `base_api.max_user_balance_satoshi`. Todo: Rejection error message.
-    - `confirms_within_blocks` MUST be 1 or higher.
+    - `confirms_within_blocks` MUST be 0 or higher.
     - `channel_expiry_blocks` MUST be 1 or greater. MUST be below or equal `base_api.max_channel_expiry_blocks`.
     - `coupon_code` MUST be a string or null.
     - `refund_onchain_address` 

--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -386,3 +386,7 @@ Todo: Describe channel object. Might be simplified or simply unnecessary.
     - `lsp_pubkey` MUST be the node id if the lsp node.
 
     
+# Open Questions
+
+- Do we allow 0conf for high lsp_balance_satoshi? Do we need something like `max_lsp_balance_satoshi` depending on the `minimum_depth`?
+- Error handling

--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -67,22 +67,21 @@ The LSP is allowed to overprovision channels/onchain-payments/onchain-fees as lo
 
 ### API information
 
-`GET /lsp/channels` is the entrypoint for each client using the api. It lists the version of the api and all supported extensions in a dictionary.
+`GET /lsp/channels` is the entrypoint for each client using the api. It lists the versions of the api and all options in a dictionary.
 
 The user MUST pull `GET /lsp/channels` to read
 
-- the `version` of the api AND version of `options` and therefore prove compatibility.
+- the `versions` of the api and therefore prove compatibility.
 - `options` properties to determine the api boundries.
 
 Example `GET /lsp/channels` response: 
 
 ```JSON
 {
-  "version": 2,
+  "versions": [2],
   "website": "http://example.com/contact",
   "options": {
     "base_api": {
-      "version": 1,
       "max_user_balance_satoshi": "0",
       "max_lsp_balance_satoshi": "100000000",
       "min_required_onchain_satoshi": null,
@@ -98,17 +97,15 @@ The base api itself has multiple properties that MUST be defined.
 
 ```json
 "options": {
-    "base_api": {
-        "version": 1,
+        "versions": [2],
         "max_user_balance_satoshi": "0",
         "max_lsp_balance_satoshi": "100000000",
         "min_required_onchain_satoshi": null,
         "max_channel_expiry_blocks": 20160
-    }
 }
 ```
 
-- `version` MUST be 1.
+- `versions` MUST be `[2]`.
 - `max_user_balance_satoshi` MUST be the maximum number of satoshi that the LSP is willing to push to the user. MUST be 0 or a positive integer.
 - `max_lsp_balance_satoshi` MUST be the maximum number of satoshi that the LSP is willing to contribute to the their balance.  MUST be 1 or greater.
 - `min_required_onchain_satoshi` MUST be the number of satoshi (`order_total_satoshi` see below) that are required for the user to pay funds onchain. The LSP MUST allow onchain payments equal or above this value. MAY be null if onchain payments are NOT supported.
@@ -127,6 +124,7 @@ The user constructs the request body depending on their needs.
 
 ```json
 {
+  "api_version": 2,
   "order": {
     "lsp_balance_satoshi": "5000000",
     "user_balance_satoshi": "2000000",
@@ -142,6 +140,7 @@ The user constructs the request body depending on their needs.
 }
 ```
 
+- `api_version` MUST be `2`. MUST match one of the versions listed by the API.
 - `order` object MUST be provided.
     - `lsp_balance_satoshi` MUST be 1 or greater. MUST be below or equal `base_api.max_lsp_balance_satoshi`.
     - `user_balance_satoshi` MUST be 0 or greater. MUST be below or equal `base_api.max_user_balance_satoshi`. Todo: Rejection error message.

--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -86,7 +86,7 @@ Example `GET /lsp/channels` response:
       "max_user_balance_satoshi": "0",
       "max_lsp_balance_satoshi": "100000000",
       "min_required_onchain_satoshi": null,
-      "max_channel_expiry_weeks": 24
+      "max_channel_expiry_blocks": 20160
     }
   }
 }
@@ -103,7 +103,7 @@ The base api itself has multiple properties that MUST be defined.
         "max_user_balance_satoshi": "0",
         "max_lsp_balance_satoshi": "100000000",
         "min_required_onchain_satoshi": null,
-        "max_channel_expiry_weeks": 24
+        "max_channel_expiry_blocks": 20160
     }
 }
 ```
@@ -112,7 +112,7 @@ The base api itself has multiple properties that MUST be defined.
 - `max_user_balance_satoshi` MUST be the maximum number of satoshi that the LSP is willing to push to the user. MUST be 0 or a positive integer.
 - `max_lsp_balance_satoshi` MUST be the maximum number of satoshi that the LSP is willing to contribute to the their balance.  MUST be 1 or greater.
 - `min_required_onchain_satoshi` MUST be the number of satoshi (`order_total_satoshi` see below) that are required for the user to pay funds onchain. The LSP MUST allow onchain payments equal or above this value. MAY be null if onchain payments are NOT supported.
-- `max_channel_expiry_weeks` MUST be the maximum length in weeks a channel can be leased for. MUST be 1 or greater.
+- `max_channel_expiry_blocks` MUST be the maximum length in blocks a channel can be leased for. MUST be 1 or greater.
 
 The user MAY abort the flow here.
 
@@ -131,7 +131,7 @@ The user constructs the request body depending on their needs.
     "lsp_balance_satoshi": "5000000",
     "user_balance_satoshi": "2000000",
     "onchain_fee_rate": 1,
-    "channel_expiry_weeks": 12,
+    "channel_expiry_blocks": 144,
     "coupon_code": "",
     "refund_onchain_address": "bc1qvmsy0f3yyes6z9jvddk8xqwznndmdwapvrc0xrmhd3vqj5rhdrrq6hz49h"
   },
@@ -146,7 +146,7 @@ The user constructs the request body depending on their needs.
     - `lsp_balance_satoshi` MUST be 1 or greater. MUST be below or equal `base_api.max_lsp_balance_satoshi`.
     - `user_balance_satoshi` MUST be 0 or greater. MUST be below or equal `base_api.max_user_balance_satoshi`. Todo: Rejection error message.
     - `onchain_fee_rate` MUST be 1 or higher. MAY be unspecified, the LSP will determine the fee rate. The LSP MAY increase this value depending on the onchain fee environment.
-    - `channel_expiry_weeks` MUST be 1 or greater. MUST be below or equal `base_api.max_channel_expiry_weeks`.
+    - `channel_expiry_blocks` MUST be 1 or greater. MUST be below or equal `base_api.max_channel_expiry_blocks`.
     - `coupon_code` MUST be a string or null.
     - `refund_onchain_address` 
       - MUST be an onchain address or null.
@@ -172,7 +172,7 @@ HTTP Code: 201 CREATED
   "lsp_balance_satoshi": "5000000",
   "user_balance_satoshi": "2000000",
   "onchain_fee_rate": 1,
-  "channel_expiry_weeks": 12,
+  "channel_expiry_blocks": 12,
   "coupon_code": "",
   "lsp_connection_strings": [
     "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f@3.33.236.230:9735",
@@ -384,7 +384,7 @@ Todo: Describe channel object. Might be simplified or simply unnecessary.
     - `opened_at` MUST be a datetime when the opening transaction has been published.
     - `open_transaction` MUST be the id the opening transaction.
     - `scid` MUST be the short channel id. MUST be null before the channel is confirmed onchain.
-    - `expires_at` MUST be a datetime when the channel may be closed by the LSP. MUST respect `channel_expiry_weeks`. MAY overprovision.
+    - `expires_at` MUST be a datetime when the channel may be closed by the LSP. MUST respect `channel_expiry_blocks`. MAY overprovision.
     - `closing_transaction` MUST be the id of the closing transaction.
     - `closed_at` MUST be a datetime when the closing transaction has been published.
     - `user_pubkey` MUST be the node id of the user node.

--- a/LSPS1/README.md
+++ b/LSPS1/README.md
@@ -113,7 +113,7 @@ The base api itself has multiple properties that MUST be defined.
 
 The user MAY abort the flow here.
 
-### 2. Create Order
+### 1. Create Order
 
 The user constructs the request body depending on their needs. 
 
@@ -212,14 +212,13 @@ HTTP Code: 201 CREATED
 - SHOULD validate `fee_total_satoshi` + `user_balance_satoshi` = `order_total_satoshi`.
 - MAY abort the flow here.
 
-
 **Errors**
 
 - 400 Bad request - Request body validation error.
 
 Todo: Define error type better. [Zmn proposal](https://github.com/BitcoinAndLightningLayerSpecs/lsp/pull/21/files#diff-603325abb5c270c90ec7c4c60eec7cb1aae620a8155519c65f974ba33ee63c54R346)
 
-### 3. Payment
+### 2. Payment
 
 This section describes the payment object returned by `POST /lsp/channel` and `GET /lsp/channel/{id}`. The user MUST pay the `lightning_invoice` OR the `onchain_address`. Using both methods MAY lead to the loss of funds.
 
@@ -273,7 +272,7 @@ Example payment object:
     - `confirmed` MUST contain a boolean if the LSP sees the transaction as confirmed.
 
 
-#### 3.1 Lightning Payment Flow
+#### 2.1 Lightning Payment Flow
 
 **User**
 
@@ -294,7 +293,7 @@ Example payment object:
 
 
 
-#### 3.2 Onchain Payment Flow
+#### 2.2 Onchain Payment Flow
 
 **User**
 
@@ -321,13 +320,13 @@ Example payment object:
 removes any confusion on how much the LPS needs to refund.
 
 
-### 4 Channel Open
+### 3 Channel Open
 
 The LSP MUST open the channel under the following conditions:
 - The open.state switched to `PENDING`
 
 
-#### 4.1 Establish Peer Connection
+#### 3.1 Establish Peer Connection
 
 **User**
 
@@ -338,7 +337,7 @@ The LSP MUST open the channel under the following conditions:
 - MAY establish a peer connection to `user_connection_string_or_pubkey`.
 
 
-#### 4.1 Open attempt
+#### 3.2 Open attempt
 
 **LSP**
 - MUST wait for a peer connection before attempting a channel open.


### PR DESCRIPTION
- Changed `channel_expiry_weeks` to `channel_expiry_blocks` as discussed in the meeting.
- Use the same version array as proposed on LSPS3. This allows for one api to support multiple versions.
- Changed `onchain_fee_rate` to `confirms_within_blocks`. This makes it more clear on how fast the channel should confirm onchain. It limits the amount of time an LSP can wait to batch channel opens and gives the user clear expectations on when the channel should be open. See transcription of our last meeting for more information.
- Added `minimum_depth` option that indicates how many block confirmations the LSP requires. `0` means the LSP supports 0conf.
- Added `supports_zero_channel_reserve` option to indicate if the LSP allows 0reserve.

`minimum_depth` and `supports_zero_channel_reserve` options are my proposal following the discussion around 0conf and 0reserve support. It clearly indicates if these non-standard methods are supported.